### PR TITLE
Configure HTMX request paths so we can use simpler URLs

### DIFF
--- a/classes/hook/before_standard_head_html_generation.php
+++ b/classes/hook/before_standard_head_html_generation.php
@@ -30,7 +30,7 @@ class before_standard_head_html_generation {
     public static function inject_htmx(): void {
         global $PAGE;
         $PAGE->requires->js(new \moodle_url('/local/htmx/htmx/htmx.min.js'));
-        $PAGE->requires->js(new \moodle_url('/local/htmx/htmx/configureRequestPaths.js'));
+        $PAGE->requires->js(new \moodle_url('/local/htmx/htmx/htmxUtils.js'));
         $PAGE->requires->js_call_amd('local_htmx/error_modal', 'init');
     }
 }

--- a/classes/hook/before_standard_head_html_generation.php
+++ b/classes/hook/before_standard_head_html_generation.php
@@ -30,6 +30,7 @@ class before_standard_head_html_generation {
     public static function inject_htmx(): void {
         global $PAGE;
         $PAGE->requires->js(new \moodle_url('/local/htmx/htmx/htmx.min.js'));
+        $PAGE->requires->js(new \moodle_url('/local/htmx/htmx/configureRequestPaths.js'));
         $PAGE->requires->js_call_amd('local_htmx/error_modal', 'init');
     }
 }

--- a/classes/htmx/hello.php
+++ b/classes/htmx/hello.php
@@ -4,9 +4,9 @@ namespace local_htmx\htmx;
 
 use local_htmx\local\templateable_handler;
 use cm_info;
-use context;
+use core\context;
 use context_system;
-use renderer_base;
+use core\output\renderer_base;
 
 class hello extends templateable_handler {
     public function required_capabilities(): array

--- a/htmx/configureRequestPaths.js
+++ b/htmx/configureRequestPaths.js
@@ -1,0 +1,10 @@
+/**
+ * Prepend the local_htmx request root to HTMX requests
+ * that don't already have it.
+ */
+document.body.addEventListener('htmx:configRequest', e => {
+    if (!e.detail.path.includes('/local/htmx/serve.php')) {
+        e.detail.path.replace(/^\//, '');
+        e.detail.path = `/local/htmx/serve.php/${e.detail.path}`;
+    }
+});

--- a/htmx/htmxUtils.js
+++ b/htmx/htmxUtils.js
@@ -2,7 +2,7 @@
  * Prepend the local_htmx request root to HTMX requests
  * that don't already have it.
  */
-document.body.addEventListener('htmx:configRequest', e => {
+htmx.on('htmx:configRequest', e => {
     if (!e.detail.path.includes('/local/htmx/serve.php')) {
         e.detail.path.replace(/^\//, '');
         e.detail.path = `/local/htmx/serve.php/${e.detail.path}`;

--- a/templates/demo.mustache
+++ b/templates/demo.mustache
@@ -1,13 +1,13 @@
 <div>
-<h4>HTXM Demo</h4>
+<h4>HTMX Demo</h4>
 
 <button
-    hx-get="/local/htmx/serve.php/local_htmx/hello"
+    hx-get="local_htmx/hello"
 >Click me!
 </button>
 
 <button
-    hx-get="/local/htmx/serve.php/local_htmx/force_error"
+    hx-get="local_htmx/force_error"
 >Click to trigger 500 response from server
 </button>
 </div>


### PR DESCRIPTION
Little snippet of JS that listens for HTMX requests and prepends the `/local/htmx/serve.php` path if the request doesn't already have it.

I also found out about the `<base>` element that works with HTMX and could be used to do similar things, but it won't work for Moodle because there are too many relative URLs (including anchor tags) that we don't want to apply this URL scheme to.